### PR TITLE
Allow non-formated seconds to be included as a value of the itunes:duration element

### DIFF
--- a/lib/rss/itunes.rb
+++ b/lib/rss/itunes.rb
@@ -303,15 +303,13 @@ module RSS
           if components.include?(nil)
             nil
           else
-            components = seconds_to_components(seconds)
-            components[0] += hours
-            components[1] += minutes
-            components.shift unless components[0] > 0
+            components.unshift(hours) if hours and hours > 0
             format_duration(components)
           end
         end
 
         private
+
         def seconds_to_components(total_seconds)
           hours = total_seconds / (60 * 60)
           minutes = (total_seconds / 60) % 60

--- a/lib/rss/itunes.rb
+++ b/lib/rss/itunes.rb
@@ -278,10 +278,10 @@ module RSS
           if do_validate and /\A(?:
                                   \d?\d:[0-5]\d:[0-5]\d|
                                   [0-5]?\d:[0-5]\d|
-                                  \d*
+                                  \d+
                                 )\z/x !~ duration
             raise ArgumentError,
-                    "must be one of (HH:MM:SS, H:MM:SS, MM:SS, M:SS, SS) : " +
+                    "must be one of HH:MM:SS, H:MM:SS, MM:SS, M:SS, S+: " +
                     duration.inspect
           end
 
@@ -299,15 +299,19 @@ module RSS
         end
 
         def construct(hours, minutes, seconds)
-          return unless minutes && seconds
-
-          components = seconds_to_components(seconds)
-          components[0] += hours
-          components[1] += minutes
-          components.shift unless components[0] > 0
-          format_duration(components)
+          components = [minutes, seconds]
+          if components.include?(nil)
+            nil
+          else
+            components = seconds_to_components(seconds)
+            components[0] += hours
+            components[1] += minutes
+            components.shift unless components[0] > 0
+            format_duration(components)
+          end
         end
 
+        private
         def seconds_to_components(total_seconds)
           hours = total_seconds / (60 * 60)
           minutes = (total_seconds / 60) % 60

--- a/lib/rss/itunes.rb
+++ b/lib/rss/itunes.rb
@@ -277,33 +277,46 @@ module RSS
         def parse(duration, do_validate=true)
           if do_validate and /\A(?:
                                   \d?\d:[0-5]\d:[0-5]\d|
-                                  [0-5]?\d:[0-5]\d
+                                  [0-5]?\d:[0-5]\d|
+                                  \d*
                                 )\z/x !~ duration
             raise ArgumentError,
-                    "must be one of HH:MM:SS, H:MM:SS, MM::SS, M:SS: " +
+                    "must be one of (HH:MM:SS, H:MM:SS, MM:SS, M:SS, SS) : " +
                     duration.inspect
           end
 
-          components = duration.split(':')
-          components[3..-1] = nil if components.size > 3
+          if duration.include?(':')
+            components = duration.split(':')
+            components[3..-1] = nil if components.size > 3
 
-          components.unshift("00") until components.size == 3
-
-          components.collect do |component|
-            component.to_i
+            components.unshift("00") until components.size == 3
+            components.collect do |component|
+              component.to_i
+            end
+          else
+            seconds_to_components(duration.to_i)
           end
         end
 
-        def construct(hour, minute, second)
-          components = [minute, second]
-          if components.include?(nil)
-            nil
-          else
-            components.unshift(hour) if hour and hour > 0
-            components.collect do |component|
-              "%02d" % component
-            end.join(":")
-          end
+        def construct(hours, minutes, seconds)
+          return unless minutes && seconds
+
+          components = seconds_to_components(seconds)
+          components[0] += hours
+          components[1] += minutes
+          components.shift unless components[0] > 0
+          format_duration(components)
+        end
+
+        def seconds_to_components(total_seconds)
+          hours = total_seconds / (60 * 60)
+          minutes = (total_seconds / 60) % 60
+          seconds = total_seconds % 60
+          [hours, minutes, seconds]
+        end
+
+        def format_duration(components)
+          components.map { |t| "%02d" % t }.join(':')
         end
       end
 

--- a/test/rss/test_itunes.rb
+++ b/test/rss/test_itunes.rb
@@ -203,8 +203,9 @@ module RSS
         _assert_itunes_duration(7, 14, 5, "7:14:05", readers, &rss20_maker)
         _assert_itunes_duration(0, 4, 55, "04:55", readers, &rss20_maker)
         _assert_itunes_duration(0, 4, 5, "4:05", readers, &rss20_maker)
+        _assert_itunes_duration(0, 0, 5, "5", readers, &rss20_maker)
+        _assert_itunes_duration(0, 3, 15, "195", readers, &rss20_maker)
 
-        _assert_itunes_duration_not_available_value("5", &rss20_maker)
         _assert_itunes_duration_not_available_value("09:07:14:05", &rss20_maker)
         _assert_itunes_duration_not_available_value("10:5", &rss20_maker)
         _assert_itunes_duration_not_available_value("10:03:5", &rss20_maker)

--- a/test/rss/test_itunes.rb
+++ b/test/rss/test_itunes.rb
@@ -205,6 +205,7 @@ module RSS
         _assert_itunes_duration(0, 4, 5, "4:05", readers, &rss20_maker)
         _assert_itunes_duration(0, 0, 5, "5", readers, &rss20_maker)
         _assert_itunes_duration(0, 3, 15, "195", readers, &rss20_maker)
+        _assert_itunes_duration(1, 0, 1, "3601", readers, &rss20_maker)
 
         _assert_itunes_duration_not_available_value("09:07:14:05", &rss20_maker)
         _assert_itunes_duration_not_available_value("10:5", &rss20_maker)
@@ -212,6 +213,7 @@ module RSS
         _assert_itunes_duration_not_available_value("10:3:05", &rss20_maker)
 
         _assert_itunes_duration_not_available_value("xx:xx:xx", &rss20_maker)
+        _assert_itunes_duration_not_available_value("", &rss20_maker)
       end
     end
 

--- a/test/rss/test_maker_itunes.rb
+++ b/test/rss/test_maker_itunes.rb
@@ -242,17 +242,26 @@ module RSS
     def assert_maker_itunes_duration(maker_readers, feed_readers=nil)
       _wrap_assertion do
         feed_readers ||= maker_readers
-        _assert_maker_itunes_duration(7, 14, 5, "07:14:05", maker_readers, feed_readers)
-        _assert_maker_itunes_duration(7, 14, 5, "7:14:05", maker_readers, feed_readers)
-        _assert_maker_itunes_duration(0, 4, 55, "04:55", maker_readers, feed_readers)
-        _assert_maker_itunes_duration(0, 4, 5, "4:05", maker_readers, feed_readers)
-        _assert_maker_itunes_duration(0, 0, 5, "0:05", maker_readers, feed_readers)
-        _assert_maker_itunes_duration_by_value(0, 5, 15, "315", maker_readers, feed_readers)
+        _assert_maker_itunes_duration(7, 14, 5, "07:14:05", maker_readers,
+                                      feed_readers)
+        _assert_maker_itunes_duration(7, 14, 5, "7:14:05", maker_readers,
+                                      feed_readers)
+        _assert_maker_itunes_duration(0, 4, 55, "04:55", maker_readers,
+                                      feed_readers)
+        _assert_maker_itunes_duration(0, 4, 5, "4:05", maker_readers,
+                                      feed_readers)
+        _assert_maker_itunes_duration(0, 0, 5, "0:05", maker_readers,
+                                      feed_readers)
+        _assert_maker_itunes_duration_by_value(0, 5, 15, "315", maker_readers,
+                                               feed_readers)
+        _assert_maker_itunes_duration_by_value(1, 0, 1, "3601", maker_readers,
+                                               feed_readers)
 
         _assert_maker_itunes_duration_invalid_value("09:07:14:05", maker_readers)
         _assert_maker_itunes_duration_invalid_value("10:5", maker_readers)
         _assert_maker_itunes_duration_invalid_value("10:03:5", maker_readers)
         _assert_maker_itunes_duration_invalid_value("10:3:05", maker_readers)
+
         _assert_maker_itunes_duration_invalid_value("xx:xx:xx", maker_readers)
       end
     end

--- a/test/rss/test_maker_itunes.rb
+++ b/test/rss/test_maker_itunes.rb
@@ -242,21 +242,17 @@ module RSS
     def assert_maker_itunes_duration(maker_readers, feed_readers=nil)
       _wrap_assertion do
         feed_readers ||= maker_readers
-        _assert_maker_itunes_duration(7, 14, 5, "07:14:05", maker_readers,
-                                      feed_readers)
-        _assert_maker_itunes_duration(7, 14, 5, "7:14:05", maker_readers,
-                                      feed_readers)
-        _assert_maker_itunes_duration(0, 4, 55, "04:55", maker_readers,
-                                      feed_readers)
-        _assert_maker_itunes_duration(0, 4, 5, "4:05", maker_readers,
-                                      feed_readers)
+        _assert_maker_itunes_duration(7, 14, 5, "07:14:05", maker_readers, feed_readers)
+        _assert_maker_itunes_duration(7, 14, 5, "7:14:05", maker_readers, feed_readers)
+        _assert_maker_itunes_duration(0, 4, 55, "04:55", maker_readers, feed_readers)
+        _assert_maker_itunes_duration(0, 4, 5, "4:05", maker_readers, feed_readers)
+        _assert_maker_itunes_duration(0, 0, 5, "0:05", maker_readers, feed_readers)
+        _assert_maker_itunes_duration_by_value(0, 5, 15, "315", maker_readers, feed_readers)
 
-        _assert_maker_itunes_duration_invalid_value("5", maker_readers)
         _assert_maker_itunes_duration_invalid_value("09:07:14:05", maker_readers)
         _assert_maker_itunes_duration_invalid_value("10:5", maker_readers)
         _assert_maker_itunes_duration_invalid_value("10:03:5", maker_readers)
         _assert_maker_itunes_duration_invalid_value("10:3:05", maker_readers)
-
         _assert_maker_itunes_duration_invalid_value("xx:xx:xx", maker_readers)
       end
     end


### PR DESCRIPTION
As mentioned in ruby/rss#4 the iTunes Podcast Spec supports the use of nonformated seconds as the value for `itunes:duration` elements:

> If you specify a single number as a value (without colons), Apple Podcasts displays the value as seconds.

source: [RSS tags for Podcasts Connect](https://help.apple.com/itc/podcasts_connect/#/itcb54353390)

I've updated the regex used in `ITunesDuration#parse` to accept any string of digits and reflect the spec point in the code by calculating from the seconds the corresponding components if no colons are present.

I've followed the "be conservative in what you send, be liberal in what you accept" [principle](https://www.wikiwand.com/en/Robustness_principle) and if a maker creates a feed by speciying just seconds:

``` rb
      item.itunes_duration = "315"
```

It will still output formatted values (eg. `05:15`).

