### PR TITLE
Only check taint on Ruby <2.7

### DIFF
--- a/lib/rss/parser.rb
+++ b/lib/rss/parser.rb
@@ -120,7 +120,7 @@ module RSS
 
       if uri.respond_to?(:read)
         uri.read
-      elsif !rss.tainted? and File.readable?(rss)
+      elsif (RUBY_VERSION >= '2.7' || !rss.tainted?) and File.readable?(rss)
         File.open(rss) {|f| f.read}
       else
         rss

--- a/test/rss/test_parser.rb
+++ b/test/rss/test_parser.rb
@@ -19,7 +19,8 @@ EOR
       @rss_tmp = Tempfile.new(%w"rss10- .rdf")
       @rss_tmp.print(@rss10)
       @rss_tmp.close
-      @rss_file = @rss_tmp.path.untaint
+      @rss_file = @rss_tmp.path
+      @rss_file.untaint if RUBY_VERSION < '2.7'
     end
 
     def teardown


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.