### PR TITLE
Added REXML to dependency explicitly.

### DIFF
--- a/rss.gemspec
+++ b/rss.gemspec
@@ -74,6 +74,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "rexml"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"


### PR DESCRIPTION
@kou I removed rexml at https://github.com/ruby/ruby/commit/c3ccf23d5807f2ff20127bf5e42df0977bf672fb. After that, the tests off rss was failed with the current master build.