### PR TITLE
Adds the 'itunes:type' tag

### DIFF
--- a/lib/rss/itunes.rb
+++ b/lib/rss/itunes.rb
@@ -53,6 +53,7 @@ module RSS
                      ["block", :yes_other],
                      ["explicit", :explicit_clean_other],
                      ["keywords", :csv],
+                     ["type"],
                      ["subtitle"],
                      ["summary"]]
   end

--- a/lib/rss/itunes.rb
+++ b/lib/rss/itunes.rb
@@ -53,7 +53,6 @@ module RSS
                      ["block", :yes_other],
                      ["explicit", :explicit_clean_other],
                      ["keywords", :csv],
-                     ["type"],
                      ["subtitle"],
                      ["summary"]]
   end
@@ -81,6 +80,7 @@ module RSS
                      ["image", :attribute, "href"],
                      ["owner", :element],
                      ["new-feed-url"],
+                     ["type", :itunes_episode],
                     ] + ITunesBaseModel::ELEMENT_INFOS
 
     class ITunesCategory < Element

--- a/lib/rss/maker/itunes.rb
+++ b/lib/rss/maker/itunes.rb
@@ -15,6 +15,8 @@ module RSS
           def_yes_other_accessor(klass, full_name)
         when :explicit_clean_other
           def_explicit_clean_other_accessor(klass, full_name)
+        when :itunes_episode
+          def_itunes_episode_accessor(klass, full_name)
         when :csv
           def_csv_accessor(klass, full_name)
         when :element, :attribute
@@ -50,6 +52,10 @@ module RSS
             Utils::ExplicitCleanOther.parse(#{full_name})
           end
         EOC
+      end
+
+      def def_itunes_episode_accessor(klass, full_name)
+        klass.def_other_element(full_name)
       end
 
       def def_csv_accessor(klass, full_name)

--- a/lib/rss/rss.rb
+++ b/lib/rss/rss.rb
@@ -577,6 +577,18 @@ EOC
       EOC
     end
 
+    def itunes_episode_writer(name, disp_name=name)
+      module_eval(<<-EOC, __FILE__, __LINE__ + 1)
+        def #{name}=(new_value)
+          if @do_validate and
+               !["episodic", "serial", nil].include?(new_value)
+            raise NotAvailableValueError.new('#{disp_name}', new_value)
+          end
+          @#{name} = new_value
+        end
+      EOC
+    end
+
     def def_children_accessor(accessor_name, plural_name)
       module_eval(<<-EOC, *get_file_and_line_from_caller(2))
       def #{plural_name}
@@ -763,9 +775,11 @@ EOC
         when :yes_other
           yes_other_writer name, disp_name
         when :csv
-          csv_writer name
+          csv_writer name, disp_name
         when :csv_integer
-          csv_integer_writer name
+          csv_integer_writer name, disp_name
+        when :itunes_episode
+          itunes_episode_writer name, disp_name
         else
           attr_writer name
         end

--- a/test/test-itunes.rb
+++ b/test/test-itunes.rb
@@ -99,6 +99,12 @@ module RSS
       end
     end
 
+    def test_type
+      assert_itunes_type(%w(channel)) do |content, xmlns|
+        make_rss20(make_channel20(content), xmlns)
+      end
+    end
+
     private
     def itunes_rss20_parse(content, &maker)
       xmlns = {"itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd"}
@@ -354,6 +360,20 @@ module RSS
                                "Red state if you're a Blue person. Or " +
                                "vice versa.",
                                readers, &rss20_maker)
+      end
+    end
+
+    def _assert_itunes_type(type, readers, &rss20_maker)
+      content = tag("itunes:type", type)
+      rss20 = itunes_rss20_parse(content, &rss20_maker)
+      target = chain_reader(rss20, readers)
+      assert_equal(type, target.itunes_type)
+    end
+
+    def assert_itunes_type(readers, &rss20_maker)
+      _wrap_assertion do
+        _assert_itunes_type("episodic", readers, &rss20_maker)
+        _assert_itunes_type("serial", readers, &rss20_maker)
       end
     end
   end

--- a/test/test-itunes.rb
+++ b/test/test-itunes.rb
@@ -73,6 +73,12 @@ module RSS
       end
     end
 
+    def test_type
+      assert_itunes_type(%w(channel)) do |content, xmlns|
+        make_rss20(make_channel20(content), xmlns)
+      end
+    end
+
     def test_owner
       assert_itunes_owner(%w(channel)) do |content, xmlns|
         make_rss20(make_channel20(content), xmlns)
@@ -96,12 +102,6 @@ module RSS
 
       assert_itunes_summary(%w(items last)) do |content, xmlns|
         make_rss20(make_channel20(make_item20(content)), xmlns)
-      end
-    end
-
-    def test_type
-      assert_itunes_type(%w(channel)) do |content, xmlns|
-        make_rss20(make_channel20(content), xmlns)
       end
     end
 
@@ -281,6 +281,28 @@ module RSS
       end
     end
 
+    def _assert_itunes_type(type, readers, &rss20_maker)
+      content = tag("itunes:type", type)
+      rss20 = itunes_rss20_parse(content, &rss20_maker)
+      target = chain_reader(rss20, readers)
+      assert_equal(type, target.itunes_type)
+    end
+
+    def _assert_itunes_type_not_available_value(value, &rss20_maker)
+      assert_not_available_value("type", value) do
+        content = tag("itunes:type", value)
+        itunes_rss20_parse(content, &rss20_maker)
+      end
+    end
+
+    def assert_itunes_type(readers, &rss20_maker)
+      _wrap_assertion do
+        _assert_itunes_type("episodic", readers, &rss20_maker)
+        _assert_itunes_type("serial", readers, &rss20_maker)
+        _assert_itunes_type_not_available_value("invalid", &rss20_maker)
+      end
+    end
+
     def _assert_itunes_owner(name, email, readers, &rss20_maker)
       content = tag("itunes:owner",
                     tag("itunes:name", name) + tag("itunes:email", email))
@@ -360,20 +382,6 @@ module RSS
                                "Red state if you're a Blue person. Or " +
                                "vice versa.",
                                readers, &rss20_maker)
-      end
-    end
-
-    def _assert_itunes_type(type, readers, &rss20_maker)
-      content = tag("itunes:type", type)
-      rss20 = itunes_rss20_parse(content, &rss20_maker)
-      target = chain_reader(rss20, readers)
-      assert_equal(type, target.itunes_type)
-    end
-
-    def assert_itunes_type(readers, &rss20_maker)
-      _wrap_assertion do
-        _assert_itunes_type("episodic", readers, &rss20_maker)
-        _assert_itunes_type("serial", readers, &rss20_maker)
       end
     end
   end

--- a/test/test-maker-itunes.rb
+++ b/test/test-maker-itunes.rb
@@ -42,6 +42,10 @@ module RSS
       assert_maker_itunes_new_feed_url(%w(channel))
     end
 
+    def test_type
+      assert_maker_itunes_type(%w(channel))
+    end
+
     def test_owner
       assert_maker_itunes_owner(%w(channel))
     end
@@ -376,6 +380,21 @@ module RSS
       end
       target = chain_reader(rss20, feed_readers)
       assert_equal(url, target.itunes_new_feed_url)
+    end
+
+    def assert_maker_itunes_type(maker_readers, feed_readers=nil)
+      feed_readers ||= maker_readers
+      type = "serial"
+
+      rss20 = ::RSS::Maker.make("rss2.0") do |maker|
+        setup_dummy_channel(maker)
+        setup_dummy_item(maker)
+
+        target = chain_reader(maker, maker_readers)
+        target.itunes_type = type
+      end
+      target = chain_reader(rss20, feed_readers)
+      assert_equal(type, target.itunes_type)
     end
 
     def _assert_maker_itunes_owner(name, email, maker_readers, feed_readers)


### PR DESCRIPTION
I was trying to parse a podcast RSS feed that contained the `<itunes:type>` situational tag used by serial podcasts.

> Extracted from [A podcaster’s guide to RSS](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) document:
>
> **episodic (default).** Specify episodic when episodes are intended to be consumed without any specific order. Apple Podcasts will present newest episodes first and display the publish date (required) of each episode. If organized into seasons, the newest season will be presented first - otherwise, episodes will be grouped by year published, newest first.
>
> **serial.** Specify serial when episodes are intended to be consumed in sequential order. Apple Podcasts will present the oldest episodes first and display the episode numbers (required) of each episode. If organized into seasons, the newest season will be presented first and  <itunes:episode> numbers must be given for each episode.

This pull request allows us to access that tag value with `channel.itunes_type`.