### PR TITLE
Exclude useless files after installation

### DIFF
--- a/rss.gemspec
+++ b/rss.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.license       = "BSD-2-Clause"
 
   spec.files = [
-    "Gemfile",
     "LICENSE.txt",
     "NEWS.md",
     "README.md",

--- a/rss.gemspec
+++ b/rss.gemspec
@@ -12,12 +12,10 @@ Gem::Specification.new do |spec|
   spec.license       = "BSD-2-Clause"
 
   spec.files = [
-    "#{spec.name}.gemspec",
     "Gemfile",
     "LICENSE.txt",
     "NEWS.md",
     "README.md",
-    "Rakefile",
   ]
   spec.files += Dir.glob("lib/**/*.rb")
   spec.test_files += Dir.glob("test/**/*")


### PR DESCRIPTION
These files are meaningless outside the working directory.