### PR TITLE
Set required ruby version in the gemspec

### DIFF
--- a/rss.gemspec
+++ b/rss.gemspec
@@ -5,6 +5,7 @@ Gem::Specification.new do |spec|
   spec.version       = RSS::VERSION
   spec.authors       = ["Kouhei Sutou"]
   spec.email         = ["kou@cozmixng.org"]
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.summary       = %q{Family of libraries that support various formats of XML "feeds".}
   spec.description   = %q{Family of libraries that support various formats of XML "feeds".}


### PR DESCRIPTION
Judging by the Ruby version matrix on the CI and the change in it per
47c67d6c9859b86ea363f951dc375b2bba32cfe4, 2.5 looks to be the last
supported version.