### PR TITLE
Exclude test_files

### DIFF
--- a/rss.gemspec
+++ b/rss.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
     "README.md",
   ]
   spec.files += Dir.glob("lib/**/*.rb")
-  spec.test_files += Dir.glob("test/**/*")
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rexml"


### PR DESCRIPTION
According to https://github.com/rubygems/guides/issues/90, `spec.test_files` is no longer in use. It also causes test files to be included in the gem.

```
$ du -sh *
4.0K	LICENSE.txt
4.0K	NEWS.md
4.0K	README.md
360K	lib
508K	test
```