### PR TITLE
itunes: add support for parsing <itunes:title> in <item>

### DIFF
--- a/lib/rss/itunes.rb
+++ b/lib/rss/itunes.rb
@@ -264,6 +264,7 @@ module RSS
         ["image", :attribute, "href"],
         ["season", :positive_integer],
         ["episode", :positive_integer],
+        ["title"]
       ]
 
     class ITunesImage < Element

--- a/test/test-itunes.rb
+++ b/test/test-itunes.rb
@@ -117,6 +117,12 @@ module RSS
       end
     end
 
+    def test_title
+      assert_itunes_title(%w(items last)) do |content, xmlns|
+        make_rss20(make_channel20(make_item20(content)), xmlns)
+      end
+    end
+
     private
     def itunes_rss20_parse(content, &maker)
       xmlns = {"itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd"}
@@ -130,6 +136,15 @@ module RSS
         rss20 = itunes_rss20_parse(tag("itunes:author", author), &rss20_maker)
         target = chain_reader(rss20, readers)
         assert_equal(author, target.itunes_author)
+      end
+    end
+
+    def assert_itunes_title(readers, &rss20_maker)
+      _wrap_assertion do
+        title = "Interview with John Lennon"
+        rss20 = itunes_rss20_parse(tag("itunes:title", title), &rss20_maker)
+        target = chain_reader(rss20, readers)
+        assert_equal(title, target.itunes_title)
       end
     end
 


### PR DESCRIPTION
The itunes: namespace and Apple Podcasts support a `<itunes:title>` element. This is mostly redundant with `<title>`, but is intended to be used to strip out episode and season numbers when using `<itunes:episode>` and `<itunes:season>`. This adds support for `<itunes:title>` on RSS items through the `item.itunes_item` method.

Reference for including itunes:title: https://help.omnystudio.com/en/articles/3219724-setting-a-separate-itunes-title-and-title-in-your-rss-feed-for-episode-titles

Sample feed including an itunes:title: https://raw.githubusercontent.com/bcomnes/jsonfeed-to-rss/master/reference/podcast.xml