### PR TITLE
itunes: support for lowercased episodeType values

### DIFF
--- a/lib/rss/rss.rb
+++ b/lib/rss/rss.rb
@@ -593,7 +593,7 @@ EOC
       module_eval(<<-DEF, *get_file_and_line_from_caller(2))
         def #{name}=(new_value)
           if @do_validate and
-               !["Full", "Trailer", "Bonus", nil].include?(new_value)
+               !["full", "trailer", "bonus", nil].include?(new_value.downcase)
             raise NotAvailableValueError.new('#{disp_name}', new_value)
           end
           @#{name} = new_value

--- a/test/test-itunes.rb
+++ b/test/test-itunes.rb
@@ -456,6 +456,8 @@ module RSS
       _wrap_assertion do
         assert_equal("Trailer",
                      set_itunes_episodeType("Trailer", readers, &rss20_maker))
+        assert_equal("trailer",
+                     set_itunes_episodeType("trailer", readers, &rss20_maker))
         assert_raise(NotAvailableValueError.new("episodeType", "Unknown")) do
           set_itunes_episodeType("Unknown", readers, &rss20_maker)
         end


### PR DESCRIPTION
I met this issue with following RSS: https://feeds.fireside.fm/smartlogic/rss

They uses lowercase values for episodeType like 'trailer' or 'full'.  I tried 2 different RSS readers with the URL and all of them read this feed without problems (liferea and some from flatpack, forget the name).  

ruby/rss raises exception:
```
RSS::NotAvailableValueError: value <trailer> of tag <episodeType> is not available. (RSS::NotAvailableValueError)
```

I also tried RSS validator, and it gave many errors but not about episodeType value: https://www.rssboard.org/rss-validator/check.cgi?url=https%3A%2F%2Ffeeds.fireside.fm%2Fsmartlogic%2Frss

Hence I understood that official specs defines Full, Trailer and Bonus as legal values for this XML tag, but looks like it's already common practice to use lowercase values (even validator doesn't think it's bad)

So here is the patch to support them + small test update with lowercase value
