### PR TITLE
doc: use URI.open in rss.rb rdoc

### DIFF
--- a/lib/rss.rb
+++ b/lib/rss.rb
@@ -26,7 +26,7 @@
 #   require 'open-uri'
 #
 #   url = 'http://www.ruby-lang.org/en/feeds/news.rss'
-#   open(url) do |rss|
+#   URI.open(url) do |rss|
 #     feed = RSS::Parser.parse(rss)
 #     puts "Title: #{feed.channel.title}"
 #     feed.items.each do |item|


### PR DESCRIPTION
Fix example usage of deprecated Kernel#open override https://github.com/ruby/open-uri/commit/53862fa35887a34a8060aebf2241874240c2986a