### PR TITLE
itunes: support lowercased episodeType values

### DIFF
--- a/lib/rss/rss.rb
+++ b/lib/rss/rss.rb
@@ -593,7 +593,7 @@ EOC
       module_eval(<<-DEF, *get_file_and_line_from_caller(2))
         def #{name}=(new_value)
           if @do_validate and
-               !["full", "trailer", "bonus", nil].include?(new_value.downcase)
+               !["Full", "full", "Trailer", "trailer", "Bonus", "bonus", nil].include?(new_value)
             raise NotAvailableValueError.new('#{disp_name}', new_value)
           end
           @#{name} = new_value

--- a/lib/rss/rss.rb
+++ b/lib/rss/rss.rb
@@ -593,7 +593,7 @@ EOC
       module_eval(<<-DEF, *get_file_and_line_from_caller(2))
         def #{name}=(new_value)
           if @do_validate and
-               !["Full", "Trailer", "Bonus", nil].include?(new_value)
+               !["full", "trailer", "bonus", nil].include?(new_value.downcase)
             raise NotAvailableValueError.new('#{disp_name}', new_value)
           end
           @#{name} = new_value

--- a/test/test-itunes.rb
+++ b/test/test-itunes.rb
@@ -456,6 +456,8 @@ module RSS
       _wrap_assertion do
         assert_equal("Trailer",
                      set_itunes_episodeType("Trailer", readers, &rss20_maker))
+        assert_equal("trailer",
+                     set_itunes_episodeType("trailer", readers, &rss20_maker))
         assert_raise(NotAvailableValueError.new("episodeType", "Unknown")) do
           set_itunes_episodeType("Unknown", readers, &rss20_maker)
         end


### PR DESCRIPTION
Forking #48 to address @kou's comment as the original author (@liberlanco) has not responded.

Fixes https://github.com/ruby/rss/issues/51#issuecomment-2129899095

Context from #48:

> Apple uses full/trailer/bonus too internally.
> See also: https://github.com/ruby/rss/issues/51#issuecomment-2129899095