### PR TITLE
fix: Improve the performance of the CONTENT_PATTERN regex in RSS parser to avoid backtracking issues.

### DIFF
--- a/lib/rss/parser.rb
+++ b/lib/rss/parser.rb
@@ -391,7 +391,7 @@ module RSS
       ns.fetch(prefix, "")
     end
 
-    CONTENT_PATTERN = /\G\s*([^=]++)=(["'])([^\2]+?)\2/
+    CONTENT_PATTERN = /\G\s*([^=]+)=(["'])([^\2]+?)\2/
     # Extract the first name="value" pair from content.
     # Works with single quotes according to the constant
     # CONTENT_PATTERN. Return a Hash.

--- a/lib/rss/parser.rb
+++ b/lib/rss/parser.rb
@@ -391,7 +391,7 @@ module RSS
       ns.fetch(prefix, "")
     end
 
-    CONTENT_PATTERN = /\s*([^=]+)=(["'])([^\2]+?)\2/
+    CONTENT_PATTERN = /\G\s*([^=]++)=(["'])([^\2]+?)\2/
     # Extract the first name="value" pair from content.
     # Works with single quotes according to the constant
     # CONTENT_PATTERN. Return a Hash.


### PR DESCRIPTION
This improves the performance of the XML stylesheet parsing a good amount.

`RSS::Parser.parse` on `<?xml-stylesheet aaaa…=?>`, Ruby 3.4.9:

| n (chars) | before (HEAD) | after (fix) | speedup |
|-----------|--------------:|------------:|--------:|
| 10,000 | 0.131 s | 0.0004 s | ~330× |
| 20,000 | 0.508 s | 0.0003 s | ~1,600× |
| 40,000 | 1.966 s | 0.0004 s | ~5,000× |
| 80,000 | 7.847 s | 0.0007 s | ~11,000× |

Fixes #66.